### PR TITLE
Fix Mink SelectorsHandler::xpathLiteral() deprecation notice.

### DIFF
--- a/Helper/Xpath.php
+++ b/Helper/Xpath.php
@@ -11,13 +11,18 @@ namespace EzSystems\BehatBundle\Helper;
 
 use Behat\Mink\Session;
 use PHPUnit_Framework_Assert as Assertion;
+use Behat\Mink\Selector\Xpath\Escaper;
 
 /**
- * This class eases the xpath creation and handling also has methods to easy search for certain 
- * content
+ * This class eases the xpath creation and handling also has methods to easy search for certain content
  */
 class Xpath
 {
+    /**
+     * @var \Behat\Mink\Selector\Xpath\Escaper $escaper
+     */
+    protected $escaper;
+
     /**
      * Initialize class
      *
@@ -26,6 +31,7 @@ class Xpath
     public function __construct( Session $session )
     {
         $this->session = $session;
+        $this->escaper = new Escaper();
     }
 
      /**
@@ -36,7 +42,7 @@ class Xpath
      */
     public function literal( $text )
     {
-        return $this->session->getSelectorsHandler()->xpathLiteral( $text );
+        return $this->escaper->escapeLiteral( $text );
     }
 
     /**


### PR DESCRIPTION
`SelectorsHandler::xpathLiteral()` is deprecated in Mink 1.7 and will be removed in 2.0.

This updates BehatBundle to use `Escaper::escapeLiteral()`, available since 1.6

Ref: https://github.com/minkphp/Mink/blob/master/src/Selector/SelectorsHandler.php#L124